### PR TITLE
Remove ACRE from relayed networks

### DIFF
--- a/relayers/CE96041EC98A5DDA.json
+++ b/relayers/CE96041EC98A5DDA.json
@@ -23,10 +23,6 @@
         {
             "ticker": "STRD",
             "relayerAddress": "stride1advdlvxlguv9fl3un29tsd9m0up5q99z5t0zvm"
-        },
-        {
-            "ticker": "ACRE",
-            "relayerAddress": "acre1ewn5hpfqlum63msxfp9pt22lyw2nmh4dz5pge4"
         }
     ]
 }


### PR DESCRIPTION
this PR removes the acre entry of GalaxyStaking.space as it stops operations on 20/08/2023