### PR TITLE
Fixed Quokka Stake telegram link

### DIFF
--- a/relayers/14BFE711AAB70C77.json
+++ b/relayers/14BFE711AAB70C77.json
@@ -2,7 +2,7 @@
     "keybaseIdentity": "14BFE711AAB70C77",
     "name": "🐹 Quokka Stake",
     "website": "https://quokkastake.io",
-    "telegram": "@quokkastake", 
+    "telegram": "quokkastake",
     "email": "quokkastake@gmail.com",
     "supportRelayerBy": "Stake with us and be safe!",
     "chainsRelayed": [


### PR DESCRIPTION
Accidentally added @ initially as a link prefix which makes it invalid, this one should make it better.