### PR TITLE
Add Quokka Stake relayer wallets - rly

### DIFF
--- a/relayers/14BFE711AAB70C77.json
+++ b/relayers/14BFE711AAB70C77.json
@@ -11,6 +11,13 @@
         { "ticker": "JKL", "relayerAddress": "jkl17ndx5qfku28ymxgmq6zq4a6d02dvpfjjd6jkt6" },
         { "ticker": "OSMO", "relayerAddress": "osmo17ndx5qfku28ymxgmq6zq4a6d02dvpfjjul0hyh" },
         { "ticker": "DVPN", "relayerAddress": "sent17ndx5qfku28ymxgmq6zq4a6d02dvpfjj0l27k2" },
-        { "ticker": "NTRN", "relayerAddress": "neutron1xqz9pemz5e5zycaa89kys5aw6m8rhgsv07va3d" }
+        { "ticker": "NTRN", "relayerAddress": "neutron1xqz9pemz5e5zycaa89kys5aw6m8rhgsv07va3d" },
+
+        { "ticker": "BTSG", "relayerAddress": "bitsong1gsjav7azmpykg0q25umkxyh3696yxd0h6jnffh" },
+        { "ticker": "ATOM", "relayerAddress": "cosmos17f6fxhs0nau206m9cafngtmvj5rrekfh4e00sf" },
+        { "ticker": "JKL", "relayerAddress": "jkl17f6fxhs0nau206m9cafngtmvj5rrekfhv8p7fk" },
+        { "ticker": "OSMO", "relayerAddress": "osmo17f6fxhs0nau206m9cafngtmvj5rrekfhazulxm" },
+        { "ticker": "DVPN", "relayerAddress": "sent17f6fxhs0nau206m9cafngtmvj5rrekfhwzek5x" },
+        { "ticker": "NTRN", "relayerAddress": "neutron17f6fxhs0nau206m9cafngtmvj5rrekfh3xxd2w" }
     ]
 }


### PR DESCRIPTION
So I deployed another relayer, rly, in addition to Hermes, which I am already running, and this PR should add rly wallets.